### PR TITLE
Update ina* config to to have an int i2c_bus to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ On the new component panel, copy and paste the following attribute template into
 
 ```json
 {
-  "i2c_bus": <int>,
+  "i2c_bus": <string>,
   "i2c-addr": <int>,
   "max_current_amps": <float>,
   "shunt_resistance": <float>
@@ -105,7 +105,7 @@ The following attributes are available for `viam:texas-instruments:ina219` and `
 
 | Attribute | Type | Required? | Description |
 | ---- | ---- | --------- | ----------- |
-| `i2c_bus` | integer | **Required** | The index of the i2c bus that the sensor is connected to. |
+| `i2c_bus` | string | **Required** | The index of the i2c bus that the sensor is connected to. |
 | `i2c_addr` | integer | Optional | The sensor's unique [i2c address](https://learn.adafruit.com/i2c-addresses/overview). Default: `0x40` |
 | `max_current_amps` | float | Optional | Default: 3.2A. The maximum current that the sensor can measure in amperes (A). |
 | `shunt_resistance` | float | Optional | Default: 0.1Ω. The shunt resistance value of the sensor in Ohms (Ω). |


### PR DESCRIPTION
The code looks for i2c_bus to be a string but it was documented to be an int.